### PR TITLE
Assign correct params for qb4w f16

### DIFF
--- a/src/configs/gemm-config.c
+++ b/src/configs/gemm-config.c
@@ -1950,7 +1950,7 @@ static void init_qd8_f16_qb4w_gemm_config(void) {
   #else
     qd8_f16_qb4w_gemm_config.minmax.dqgemm_bl[XNN_MR_TO_INDEX(1)] = xnn_init_hmp_dqgemm_bl_ukernel((xnn_dqgemm_bl_ukernel_fn) xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x8__scalar);
     qd8_f16_qb4w_gemm_config.minmax.dqgemm_bl[XNN_MR_TO_INDEX(2)] = xnn_init_hmp_dqgemm_bl_ukernel((xnn_dqgemm_bl_ukernel_fn) xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x8__scalar);
-    qd8_f16_qb4w_gemm_config.init.f32_qc4w = xnn_init_f16_qc4w_minmax_scalar_params;
+    qd8_f16_qb4w_gemm_config.init.f16_qc4w = xnn_init_f16_qc4w_minmax_scalar_params;
     qd8_f16_qb4w_gemm_config.pack_gemm_goi_bl = (xnn_packw_gemm_goi_bl_ukernel_fn) xnn_pack_qs8_qc4w_gemm_bl_goi_w;
     qd8_f16_qb4w_gemm_config.mr = 2;
     qd8_f16_qb4w_gemm_config.nr = 8;


### PR DESCRIPTION
This is need for fp16 qb4w. Missed in the previous PR. Tested via FB internal.